### PR TITLE
Add comprehensive unit tests, CI/CD pipelines, and documentation

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,64 +1,78 @@
-name: Ubuntu Build
+name: Ubuntu Build & Test
 
 on:
   push:
-    branches: [ main ]
+    branches: ['**']
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
-  build:
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  build-test-coverage:
     runs-on: ubuntu-latest
+
     steps:
-    
-    - name: Install gcc-11
-      run: |
-        sudo apt install build-essential manpages-dev software-properties-common
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt update
-        sudo apt install gcc-11 g++-11 ninja-build
+      - uses: actions/checkout@v3
 
-    
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v2
-      with:
-        version: '6.2.0'
-        host: 'linux'
-        target: 'desktop'
-        install-deps: 'true'
-    
-    - name: Find Qt 6
-      if: ${{ startsWith(matrix.qt_ver, '6') }}
-      run: |
-        echo 'Qt6_DIR = ${{ env.Qt6_DIR }}'
-        echo 'Qt_DIR=${{ env.Qt6_DIR }}' >> ${GITHUB_ENV}
-    
-    - name: Configure Qt env
-      run: echo '${{ env.Qt_DIR }}/bin' >> ${GITHUB_PATH}
-    
-    - name: Test Qt & env
-      run: |
-        echo ${PATH}
-        which 'qmake'
-        qmake '-query'
-    
-    - uses: actions/checkout@v2   
-    - name: Configure CMake
-      env:  
-        CMAKE_PREFIX_PATH: ${{env.Qt6_DIR}}
-      run: |
-        rm -f CMakeCache.txt
-        CXX=g++-11 CC=gcc-11 cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -G Ninja
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            software-properties-common \
+            gcc-11 \
+            g++-11 \
+            ninja-build \
+            lcov
 
-    - name: Build
-      run: CXX=g++-11 CC=gcc-11 cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+        with:
+          version: '6.2.0'
+          host: linux
+          target: desktop
+          install-deps: true
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
-      
+      - name: Configure CMake
+        env:
+          CMAKE_PREFIX_PATH: ${{ env.Qt6_DIR }}
+        run: |
+          CXX=g++-11 CC=gcc-11 cmake -B ${{ github.workspace }}/build \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -DBUILD_TESTS=ON \
+            -DCOVERAGE=ON \
+            -G Ninja
+
+      - name: Build
+        run: cmake --build ${{ github.workspace }}/build
+
+      - name: Test
+        working-directory: ${{ github.workspace }}/build
+        env:
+          QPA_PLATFORM: offscreen
+        run: ctest -C ${{ env.BUILD_TYPE }} --output-on-failure
+
+      - name: Generate coverage report
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          lcov --capture --directory . \
+               --output-file coverage.info \
+               --gcov-tool gcov-11
+          lcov --remove coverage.info \
+               '/usr/*' '*/tests/*' '*/Qt*' \
+               --output-file coverage.info
+          genhtml coverage.info --output-directory coverage_html
+
+      - name: Upload coverage HTML as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: ${{ github.workspace }}/build/coverage_html
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ${{ github.workspace }}/build/coverage.info
+          fail_ci_if_error: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,8 +17,7 @@ jobs:
         shell: msys2 {0}
 
     steps:
-      - uses: actions/checkout@v2
-      
+      - uses: actions/checkout@v3
 
       - uses: msys2/setup-msys2@v2
         with:
@@ -27,42 +26,21 @@ jobs:
           release: false
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         with:
           version: '6.2.0'
-          host: "windows"
-          target: "desktop"
-          arch: "win64_msvc2019_64"
-          dir: "${{github.workspace}}/qt/"
-          install-deps: "true"
-          
-      - uses: lukka/get-cmake@latest 
-      - name: Download Ninja and CMake
-        id: cmake_and_ninja
-        shell: cmake -P {0}
-        run: |
-          set(ninja_version "1.9.0")
-          set(cmake_version "3.16.2")
-          message(STATUS "Using host CMake version: ${CMAKE_VERSION}")
-          set(ninja_suffix "win.zip")
-          set(cmake_suffix "win64-x64.zip")
-          set(cmake_dir "cmake-${cmake_version}-win64-x64/bin")
-          
-          set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v${ninja_version}/ninja-${ninja_suffix}")
-          file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
-          execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
+          host: windows
+          target: desktop
+          arch: win64_msvc2019_64
+          dir: ${{ github.workspace }}/qt/
+          install-deps: true
 
-          set(cmake_url "https://github.com/Kitware/CMake/releases/download/v${cmake_version}/cmake-${cmake_version}-${cmake_suffix}")
-          file(DOWNLOAD "${cmake_url}" ./cmake.zip SHOW_PROGRESS)
-          execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./cmake.zip)
+      - uses: lukka/get-cmake@latest
 
-          # Save the path for other steps
-          file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/${cmake_dir}" cmake_dir)
-          message("::set-output name=cmake_dir::${cmake_dir}")
-    
       - name: Configure CMake
         env:
-          CMAKE_PREFIX_PATH: ${{env.Qt6_Dir}}
-        run: cmake -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -G "Ninja" -B '${{github.workspace}}'/build
+          CMAKE_PREFIX_PATH: ${{ env.Qt6_DIR }}
+        run: cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -G "Ninja" -B '${{ github.workspace }}'/build
+
       - name: Build
-        run: cmake --build '${{github.workspace}}'/build
+        run: cmake --build '${{ github.workspace }}'/build

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ Thumbs.db
 *.dll
 *.exe
 
+# CMake build directories
+build/
+build-*/
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,129 @@
+# CLAUDE.md
+
+This file provides guidance for AI coding assistants (Claude Code and others) working on this repository.
+
+## Project Overview
+
+**QMineSweeper** is a classic MineSweeper game built with **Qt6** and **C++20**. The game features a 15×15 grid with 20 randomly placed mines, a flag system, and an elapsed-time display.
+
+- **Language**: C++20
+- **GUI Framework**: Qt6 (Widgets)
+- **Build System**: CMake 3.5+
+- **Supported Platforms**: Linux, Windows
+
+## Repository Structure
+
+```
+QMineSweeper/
+├── main.cpp              # Entry point — initializes QApplication, loads translation, shows MainWindow
+├── mainwindow.cpp/h      # Main window with timer (50 ms tick) and mine-count label
+├── mainwindow.ui         # Qt Designer UI file
+├── minefield.cpp/h       # MineField widget — 15×15 grid, mine placement, number calculation
+├── minebutton.cpp/h      # MineButton (QPushButton subclass) — per-cell state and interaction
+├── resources.qrc         # Embedded icons (explosion.png, redflag.png)
+├── icons/                # Source icon files
+├── tests/                # Unit tests (Qt Test framework)
+│   ├── CMakeLists.txt
+│   ├── tst_minefield.cpp
+│   └── tst_minebutton.cpp
+└── .github/workflows/    # CI/CD pipelines
+    ├── ubuntu.yml        # Build + test + coverage (Linux)
+    ├── windows.yml       # Build only (Windows)
+    ├── formatter.yml     # clang-format enforcement
+    └── release.yml       # Automated GitHub releases on version tags
+```
+
+## Architecture
+
+```
+MainWindow
+  └── MineField (QWidget)          — manages the 15×15 grid
+        └── MineButton[15][15]     — each cell (QPushButton subclass)
+```
+
+- **MineField** owns all buttons, places mines randomly with `fillMines()`, calculates adjacent mine counts with `fillNumbers()`, and recursively reveals empty regions via `checkNeighbours()`.
+- **MineButton** handles left-click (open) and right-click (flag/unflag) interactions, emits `checkNeighbours` (cascade) or `explosion` (mine hit) signals.
+- **MainWindow** connects signals to game-over and timer logic.
+
+## Build Requirements
+
+- CMake 3.5+
+- Qt 6.2+ (Widgets module; Test module for tests)
+- GCC 11+ (Linux) or MSVC 2019+ (Windows)
+- Ninja (optional, recommended for faster builds)
+
+## Common Commands
+
+### Standard build (Release)
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja
+cmake --build build
+./build/QMineSweeper
+```
+
+### Build with unit tests
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -G Ninja
+cmake --build build
+cd build && QPA_PLATFORM=offscreen ctest --output-on-failure
+```
+
+### Build with tests and coverage report
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DCOVERAGE=ON -G Ninja
+cmake --build build
+cd build && QPA_PLATFORM=offscreen ctest --output-on-failure
+lcov --capture --directory . --output-file coverage.info --gcov-tool gcov-11
+lcov --remove coverage.info '/usr/*' '*/tests/*' '*/Qt*' --output-file coverage.info
+genhtml coverage.info --output-directory coverage_html
+# Open coverage_html/index.html in a browser
+```
+
+### Format code
+```bash
+clang-format -i *.cpp *.h
+```
+
+## CMake Options
+
+| Option          | Default | Description                                |
+|-----------------|---------|--------------------------------------------|
+| `BUILD_TESTS`   | `OFF`   | Build the Qt Test unit test executables    |
+| `COVERAGE`      | `OFF`   | Add `--coverage` flags for gcov/lcov       |
+| `CMAKE_BUILD_TYPE` | —    | Use `Debug` for tests/coverage, `Release` for production |
+
+## Code Style
+
+- **Formatter**: clang-format (LLVM style)
+- **Indent**: 4 spaces (no tabs)
+- **Column limit**: 240 characters
+- **Braces**: Allman style
+- CI enforces formatting on every push via `formatter.yml`.
+- Run `clang-format -i *.cpp *.h` before committing.
+
+## Testing
+
+Tests live in `tests/` and use the **Qt Test** framework (`QTest`).
+
+- `tst_minefield` — tests MineField grid dimensions, mine count, number consistency, flag count
+- `tst_minebutton` — tests MineButton state (mined, opened, flagged), number storage, signals
+
+Tests require `QPA_PLATFORM=offscreen` in headless environments (CI, SSH sessions without a display).
+
+## CI/CD Workflows
+
+| Workflow         | Trigger                        | What it does                                     |
+|------------------|--------------------------------|--------------------------------------------------|
+| `ubuntu.yml`     | Push / PR to any branch        | Build (Debug) + run tests + generate coverage    |
+| `windows.yml`    | Push / PR to main              | Build (Release) only                             |
+| `formatter.yml`  | Every push                     | Check clang-format compliance                    |
+| `release.yml`    | Push of `v*` tag               | Build both platforms, create GitHub Release      |
+
+## Development Branch
+
+Active development for docs/tests/CI happens on:
+```
+claude/add-docs-tests-cicd-H45cs
+```
+
+Use `git push -u origin claude/add-docs-tests-cicd-H45cs` to push changes.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(QMineSweeper VERSION 0.1 LANGUAGES CXX)
 
+enable_testing()
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(CMAKE_AUTOUIC ON)
@@ -75,4 +77,9 @@ set_target_properties(QMineSweeper PROPERTIES
 
 if(QT_VERSION_MAJOR EQUAL 6)
     qt_finalize_executable(QMineSweeper)
+endif()
+
+option(BUILD_TESTS "Build unit tests" OFF)
+if(BUILD_TESTS)
+    add_subdirectory(tests)
 endif()

--- a/minebutton.h
+++ b/minebutton.h
@@ -32,6 +32,9 @@ class MineButton : public QPushButton
     uint Number();
     bool isOpened();
     void Open();
+    uint getX() const { return m_x; }
+    uint getY() const { return m_y; }
+    bool isFlagged() const { return m_isFlaged; }
   signals:
     void checkNeighbours(uint m_x, uint m_y);
     void explosion(uint m_x, uint m_y);

--- a/minefield.h
+++ b/minefield.h
@@ -15,6 +15,13 @@ class MineField : public QWidget
     void incrementflagCount();
     void getMineCountLabel(QLabel *label);
 
+    // Accessors used by unit tests
+    MineButton *getButton(uint i, uint j) { return MButtons[i][j]; }
+    int getFlagCount() const { return flagCount; }
+    static constexpr uint getWidth() { return Width; }
+    static constexpr uint getHeight() { return Height; }
+    static constexpr int getMineCount() { return MineCount; }
+
   public slots:
     void checkNeighbours(uint i, uint j);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.5)
+
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test Widgets REQUIRED)
+
+# ── MineField tests ──────────────────────────────────────────────────────────
+add_executable(tst_minefield
+    tst_minefield.cpp
+    ../minefield.cpp
+    ../minebutton.cpp
+    ../resources.qrc
+)
+target_include_directories(tst_minefield PRIVATE ..)
+target_link_libraries(tst_minefield PRIVATE
+    Qt${QT_VERSION_MAJOR}::Test
+    Qt${QT_VERSION_MAJOR}::Widgets
+)
+add_test(NAME tst_minefield COMMAND tst_minefield)
+set_tests_properties(tst_minefield PROPERTIES ENVIRONMENT "QPA_PLATFORM=offscreen")
+
+# ── MineButton tests ─────────────────────────────────────────────────────────
+add_executable(tst_minebutton
+    tst_minebutton.cpp
+    ../minefield.cpp
+    ../minebutton.cpp
+    ../resources.qrc
+)
+target_include_directories(tst_minebutton PRIVATE ..)
+target_link_libraries(tst_minebutton PRIVATE
+    Qt${QT_VERSION_MAJOR}::Test
+    Qt${QT_VERSION_MAJOR}::Widgets
+)
+add_test(NAME tst_minebutton COMMAND tst_minebutton)
+set_tests_properties(tst_minebutton PROPERTIES ENVIRONMENT "QPA_PLATFORM=offscreen")
+
+# ── Coverage instrumentation (GCC only) ─────────────────────────────────────
+if(COVERAGE)
+    foreach(target tst_minefield tst_minebutton)
+        target_compile_options(${target} PRIVATE --coverage -O0 -g)
+        target_link_libraries(${target} PRIVATE --coverage)
+    endforeach()
+endif()

--- a/tests/tst_minebutton.cpp
+++ b/tests/tst_minebutton.cpp
@@ -1,0 +1,185 @@
+#include <QApplication>
+#include <QSignalSpy>
+#include <QTest>
+
+#include "minefield.h"
+#include "minebutton.h"
+
+// Helper: find a non-mined button with Number()==0 (fully empty cell)
+static MineButton *findEmptyButton(MineField &field)
+{
+    for (uint i = 0; i < MineField::getHeight(); ++i)
+        for (uint j = 0; j < MineField::getWidth(); ++j)
+        {
+            MineButton *btn = field.getButton(i, j);
+            if (!btn->isMined() && btn->Number() == 0)
+                return btn;
+        }
+    return nullptr;
+}
+
+// Helper: find a non-mined button with Number() > 0 (numbered cell)
+static MineButton *findNumberedButton(MineField &field)
+{
+    for (uint i = 0; i < MineField::getHeight(); ++i)
+        for (uint j = 0; j < MineField::getWidth(); ++j)
+        {
+            MineButton *btn = field.getButton(i, j);
+            if (!btn->isMined() && btn->Number() > 0)
+                return btn;
+        }
+    return nullptr;
+}
+
+// Helper: find a mined button
+static MineButton *findMinedButton(MineField &field)
+{
+    for (uint i = 0; i < MineField::getHeight(); ++i)
+        for (uint j = 0; j < MineField::getWidth(); ++j)
+        {
+            MineButton *btn = field.getButton(i, j);
+            if (btn->isMined())
+                return btn;
+        }
+    return nullptr;
+}
+
+class TestMineButton : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testInitialState();
+    void testSetMined();
+    void testSetAndGetNumber();
+    void testSetNumberIgnoredWhenMined();
+    void testPositions();
+    void testOpenSetsOpened();
+    void testOpenEmptyEmitsCheckNeighbours();
+    void testOpenMinedEmitsExplosion();
+};
+
+// Freshly constructed buttons are not mined, not opened, not flagged
+void TestMineButton::testInitialState()
+{
+    MineField field;
+    for (uint i = 0; i < MineField::getHeight(); ++i)
+    {
+        for (uint j = 0; j < MineField::getWidth(); ++j)
+        {
+            MineButton *btn = field.getButton(i, j);
+            // isFlagged starts false
+            QVERIFY(!btn->isFlagged());
+            // isOpened starts false
+            QVERIFY(!btn->isOpened());
+        }
+    }
+}
+
+// setMined() flips isMined() from false to true
+void TestMineButton::testSetMined()
+{
+    MineField field;
+    // Pick the first non-mined button and mark it
+    for (uint i = 0; i < MineField::getHeight(); ++i)
+    {
+        for (uint j = 0; j < MineField::getWidth(); ++j)
+        {
+            MineButton *btn = field.getButton(i, j);
+            if (!btn->isMined())
+            {
+                btn->setMined();
+                QVERIFY(btn->isMined());
+                return;
+            }
+        }
+    }
+    QFAIL("No non-mined button found");
+}
+
+// setNumber / Number round-trip for values 1–8 on a non-mined cell
+void TestMineButton::testSetAndGetNumber()
+{
+    MineField field;
+    MineButton *btn = nullptr;
+    for (uint i = 0; i < MineField::getHeight() && !btn; ++i)
+        for (uint j = 0; j < MineField::getWidth() && !btn; ++j)
+            if (!field.getButton(i, j)->isMined())
+                btn = field.getButton(i, j);
+
+    QVERIFY(btn != nullptr);
+
+    for (uint n = 1; n <= 8; ++n)
+    {
+        btn->setNumber(n);
+        QCOMPARE(btn->Number(), n);
+    }
+}
+
+// setNumber() on a mined button must NOT overwrite the stored number
+void TestMineButton::testSetNumberIgnoredWhenMined()
+{
+    MineField field;
+    MineButton *btn = findMinedButton(field);
+    if (!btn)
+        QSKIP("No mined button available");
+
+    uint before = btn->Number();
+    btn->setNumber(5);
+    QCOMPARE(btn->Number(), before);
+}
+
+// Every button's getX()/getY() must equal its row/column in the grid
+void TestMineButton::testPositions()
+{
+    MineField field;
+    for (uint i = 0; i < MineField::getHeight(); ++i)
+        for (uint j = 0; j < MineField::getWidth(); ++j)
+        {
+            MineButton *btn = field.getButton(i, j);
+            QCOMPARE(btn->getX(), i);
+            QCOMPARE(btn->getY(), j);
+        }
+}
+
+// Open() marks the button as opened
+void TestMineButton::testOpenSetsOpened()
+{
+    MineField field;
+    MineButton *btn = findNumberedButton(field);
+    if (!btn)
+        QSKIP("No numbered button available");
+
+    QVERIFY(!btn->isOpened());
+    btn->Open();
+    QVERIFY(btn->isOpened());
+}
+
+// Opening a cell with Number()==0 and not mined emits checkNeighbours
+void TestMineButton::testOpenEmptyEmitsCheckNeighbours()
+{
+    MineField field;
+    MineButton *btn = findEmptyButton(field);
+    if (!btn)
+        QSKIP("No empty (number==0, non-mined) button found in this layout");
+
+    QSignalSpy spy(btn, &MineButton::checkNeighbours);
+    btn->Open();
+    QVERIFY(spy.count() >= 1);
+}
+
+// Opening a mined cell emits explosion
+void TestMineButton::testOpenMinedEmitsExplosion()
+{
+    MineField field;
+    MineButton *btn = findMinedButton(field);
+    if (!btn)
+        QSKIP("No mined button available");
+
+    QSignalSpy spy(btn, &MineButton::explosion);
+    btn->Open();
+    QVERIFY(spy.count() >= 1);
+}
+
+QTEST_MAIN(TestMineButton)
+#include "tst_minebutton.moc"

--- a/tests/tst_minebutton.cpp
+++ b/tests/tst_minebutton.cpp
@@ -2,8 +2,8 @@
 #include <QSignalSpy>
 #include <QTest>
 
-#include "minefield.h"
 #include "minebutton.h"
+#include "minefield.h"
 
 // Helper: find a non-mined button with Number()==0 (fully empty cell)
 static MineButton *findEmptyButton(MineField &field)
@@ -48,7 +48,7 @@ class TestMineButton : public QObject
 {
     Q_OBJECT
 
-private slots:
+  private slots:
     void testInitialState();
     void testSetMined();
     void testSetAndGetNumber();

--- a/tests/tst_minefield.cpp
+++ b/tests/tst_minefield.cpp
@@ -1,14 +1,14 @@
 #include <QApplication>
 #include <QTest>
 
-#include "minefield.h"
 #include "minebutton.h"
+#include "minefield.h"
 
 class TestMineField : public QObject
 {
     Q_OBJECT
 
-private slots:
+  private slots:
     void testDimensions();
     void testMineCountBounds();
     void testFillNumbersConsistency();

--- a/tests/tst_minefield.cpp
+++ b/tests/tst_minefield.cpp
@@ -1,0 +1,103 @@
+#include <QApplication>
+#include <QTest>
+
+#include "minefield.h"
+#include "minebutton.h"
+
+class TestMineField : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testDimensions();
+    void testMineCountBounds();
+    void testFillNumbersConsistency();
+    void testInitialFlagCount();
+    void testIncrementFlagCount();
+    void testGetButtonNonNull();
+};
+
+// Grid constants match the game definition
+void TestMineField::testDimensions()
+{
+    QCOMPARE(MineField::getWidth(), 15u);
+    QCOMPARE(MineField::getHeight(), 15u);
+    QCOMPARE(MineField::getMineCount(), 20);
+}
+
+// fillMines() uses rand() with no duplicate-prevention, so the actual mined
+// count may be < MineCount when placements collide. At least 1 mine must exist.
+void TestMineField::testMineCountBounds()
+{
+    MineField field;
+
+    int mined = 0;
+    for (uint i = 0; i < MineField::getHeight(); ++i)
+        for (uint j = 0; j < MineField::getWidth(); ++j)
+            if (field.getButton(i, j)->isMined())
+                ++mined;
+
+    QVERIFY2(mined >= 1, "Expected at least 1 mine");
+    QVERIFY2(mined <= MineField::getMineCount(), "More mines than MineCount");
+}
+
+// For every non-mined cell, Number() must equal the count of mined neighbours
+void TestMineField::testFillNumbersConsistency()
+{
+    MineField field;
+
+    const int H = static_cast<int>(MineField::getHeight());
+    const int W = static_cast<int>(MineField::getWidth());
+
+    for (int i = 0; i < H; ++i)
+    {
+        for (int j = 0; j < W; ++j)
+        {
+            MineButton *btn = field.getButton(static_cast<uint>(i), static_cast<uint>(j));
+            if (btn->isMined())
+                continue;
+
+            uint expected = 0;
+            for (int a = -1; a <= 1; ++a)
+                for (int b = -1; b <= 1; ++b)
+                    if (i + a >= 0 && i + a < H && j + b >= 0 && j + b < W)
+                        expected += field.getButton(static_cast<uint>(i + a), static_cast<uint>(j + b))->isMined() ? 1u : 0u;
+
+            QCOMPARE(btn->Number(), expected);
+        }
+    }
+}
+
+// Flag count starts at zero
+void TestMineField::testInitialFlagCount()
+{
+    MineField field;
+    QCOMPARE(field.getFlagCount(), 0);
+}
+
+// incrementflagCount() increments the internal counter
+void TestMineField::testIncrementFlagCount()
+{
+    MineField field;
+    // Wire up the label that incrementflagCount() writes to
+    QLabel label;
+    field.getMineCountLabel(&label);
+
+    field.incrementflagCount();
+    QCOMPARE(field.getFlagCount(), 1);
+
+    field.incrementflagCount();
+    QCOMPARE(field.getFlagCount(), 2);
+}
+
+// getButton() must return a valid pointer for every cell in the grid
+void TestMineField::testGetButtonNonNull()
+{
+    MineField field;
+    for (uint i = 0; i < MineField::getHeight(); ++i)
+        for (uint j = 0; j < MineField::getWidth(); ++j)
+            QVERIFY(field.getButton(i, j) != nullptr);
+}
+
+QTEST_MAIN(TestMineField)
+#include "tst_minefield.moc"


### PR DESCRIPTION
## Summary
This PR adds a complete testing infrastructure, CI/CD workflows, and developer documentation to QMineSweeper. It includes two new test suites covering MineField and MineButton functionality, automated build/test/coverage pipelines for Ubuntu and Windows, and a CLAUDE.md guide for AI assistants.

## Key Changes

### Testing Infrastructure
- **`tests/tst_minefield.cpp`**: 6 test cases covering grid dimensions, mine count bounds, number consistency, and flag counting
- **`tests/tst_minebutton.cpp`**: 8 test cases covering button state (mined, opened, flagged), number storage, and signal emission (checkNeighbours, explosion)
- **`tests/CMakeLists.txt`**: Build configuration for both test executables with Qt Test framework, coverage instrumentation support, and headless environment setup

### CI/CD Workflows
- **`.github/workflows/ubuntu.yml`** (refactored): 
  - Changed from Release to Debug build for better test coverage
  - Added Qt Test execution with `QPA_PLATFORM=offscreen`
  - Integrated lcov coverage report generation and upload to Codecov
  - Simplified dependency installation and CMake configuration
  
- **`.github/workflows/windows.yml`** (updated):
  - Upgraded action versions (checkout@v3, install-qt-action@v3)
  - Simplified CMake/Ninja download logic (now handled by lukka/get-cmake)
  - Improved environment variable formatting

### Code Enhancements
- **`minefield.h`**: Added public accessor methods for unit tests (`getButton()`, `getFlagCount()`, `getWidth()`, `getHeight()`, `getMineCount()`)
- **`minebutton.h`**: Added public getter methods (`getX()`, `getY()`, `isFlagged()`) for test access
- **`CMakeLists.txt`**: Added `enable_testing()`, `BUILD_TESTS` option, and tests subdirectory integration
- **`.gitignore`**: Added CMake build directories (`build/`, `build-*/`)

### Documentation
- **`CLAUDE.md`**: Comprehensive guide covering project overview, repository structure, architecture, build requirements, common commands, CMake options, code style, testing framework, and CI/CD workflow details

## Implementation Details
- Tests use Qt Test framework with signal spies (`QSignalSpy`) to verify signal emission
- Helper functions in test files locate specific button types (empty, numbered, mined) for flexible test scenarios
- Coverage instrumentation uses GCC's `--coverage` flag with gcov-11 and lcov for report generation
- All tests run in headless mode (`QPA_PLATFORM=offscreen`) for CI compatibility
- Ubuntu workflow now triggers on all branches; Windows workflow remains main-only

https://claude.ai/code/session_01CcnzruhSnuqg39SukDG2uB