### PR TITLE
fix(ci): set APPIMAGE_EXTRACT_AND_RUN for linuxdeploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,7 @@ jobs:
 
       - name: Create AppImage
         env:
+          APPIMAGE_EXTRACT_AND_RUN: '1'
           QMAKE: ${{ env.QT_ROOT_DIR }}/bin/qmake
           OUTPUT: QMineSweeper-x86_64.AppImage
           VERSION: ${{ needs.resolve-tag.outputs.release_tag }}


### PR DESCRIPTION
## Summary
- Fix Linux build failure in the release workflow by setting `APPIMAGE_EXTRACT_AND_RUN=1` for the AppImage creation step
- `linuxdeploy` is an AppImage that requires FUSE, which is unavailable in GitHub Actions runners — this env var makes it extract-and-run instead
- This was the root cause of both failed release runs (the \"Publish GitHub Release\" job was skipped because `build-linux` failed)

## Test plan
- [ ] Verify the Linux build job passes in CI
- [ ] After merge, update `release/v1.0.0` branch to re-trigger the release workflow
- [ ] Confirm the GitHub Release is published with all 3 platform artifacts

https://claude.ai/code/session_012huGfUZqELUJWhtgDkDNRX