### PR TITLE
feat(stats): record best-time date (v1.3.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(QMineSweeper
-    VERSION 1.2.0
+    VERSION 1.3.0
     DESCRIPTION "A Qt6-based Minesweeper game"
     HOMEPAGE_URL "https://github.com/Mavrikant/QMineSweeper"
     LANGUAGES CXX

--- a/CYCLES.md
+++ b/CYCLES.md
@@ -1,0 +1,33 @@
+# Autonomous cycles log
+
+## 2026-04-23 — Cycle 1 — v1.3.0
+
+- **Chosen problem:** Lifetime best-time records had no date context —
+  you could see you'd done Beginner in 15.5 s, but not whether that was
+  yesterday or three years ago. Small but real UX gap in the Statistics
+  dialog added in v1.2.0.
+- **Evidence:** Stats dialog (`showStatsDialog` in `mainwindow.cpp`)
+  renders only `played / won / best time` with no timestamp; QSettings
+  tree stored only `{played, won, best_seconds}`.
+- **Shipped:**
+  - Branch: `feat/best-time-date`
+  - PR: (pending — see below)
+  - Commit: `15bdcad` on `feat/best-time-date`
+  - Release tag: `v1.3.0` (pending)
+- **Assumptions made:**
+  - Day precision is sufficient (no wall-clock time) — the date is a
+    memory anchor, not an audit trail.
+  - Inline date rendering after the best-time cell avoids a new column
+    header and therefore zero new translatable strings (important given
+    the project's hand-translation-only policy for all 10 locales).
+- **Skipped:**
+  - *Per-locale date format override* — QLocale::ShortFormat respects
+    the active QLocale already; no explicit override needed.
+  - *"Best date" on the end-of-game "New record!" dialog* — cosmetic,
+    not in this cycle's scope.
+- **Risks logged:** none.
+- **Next candidates:**
+  - Pause / resume (P shortcut) with board-covering overlay. Real user
+    pain for timed runs that get interrupted.
+  - Custom difficulty dialog (width × height × mine count).
+  - Keyboard navigation (arrow keys + space/F) for accessibility.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,35 @@
+# Cycle decisions
+
+## 2026-04-23 — Best-time date in Statistics (v1.3.0)
+
+**Chosen:** Record the date a best-time was set and show it inline in the
+Statistics dialog after the best-time value.
+
+**Rejected alternatives:**
+- *Pause / resume* — larger surface (overlay widget, timer arithmetic, three new
+  user-facing strings across 10 locales), higher risk of regression in the
+  existing timer/state machine. Park for a later cycle.
+- *Custom difficulty* — introduces a second axis (what do we do with stats for
+  arbitrary grid configs?) and more UX surface. Park for a later cycle.
+- *Keyboard navigation* — touches focus management on every cell; nice but not
+  the biggest lever and the current mouse UX is fine.
+
+**Why this one:**
+- Concrete user value — a lifetime record is much more meaningful when you can
+  see *when* you set it; serves as a "last played" memento for casual players.
+- Backwards compatible — a Record written by v1.2.0 has no `best_date`; we
+  render a blank date for that case. No migration needed.
+- Testable via the existing `Stats` unit suite — time/date is injectable.
+- Ships with zero new translatable strings — the locale-formatted date goes
+  inline in the existing *Best time* cell (e.g. `15.5 s (2026-04-23)`),
+  avoiding the "new strings ship English-only to 9 locales" footgun.
+
+**Assumptions:**
+- Date-only precision is sufficient (no hour/minute). Reasoning: the "when" is
+  for memory anchoring, not audit — day granularity is enough and keeps the
+  cell short.
+- ISO 8601 (`yyyy-MM-dd`) is the canonical persistence format; display uses
+  `QLocale::toString(date, QLocale::ShortFormat)` so the user sees a familiar
+  format in their locale.
+- `resetAll()` already wipes the `stats/` settings group, so the new
+  `best_date` key is cleared automatically — no code change needed for reset.

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -14,6 +14,7 @@
 #include <QHeaderView>
 #include <QKeySequence>
 #include <QLabel>
+#include <QLocale>
 #include <QMessageBox>
 #include <QProcess>
 #include <QPushButton>
@@ -400,7 +401,22 @@ void MainWindow::showStatsDialog()
     for (int i = 0; i < 3; ++i)
     {
         const Stats::Record rec = Stats::load(QString::fromLatin1(rows[i].key));
-        const QString best = rec.bestSeconds > 0.0 ? QString::asprintf("%.1f s", rec.bestSeconds) : QStringLiteral("—");
+        QString best;
+        if (rec.bestSeconds > 0.0)
+        {
+            best = QString::asprintf("%.1f s", rec.bestSeconds);
+            if (rec.bestDate.isValid())
+            {
+                // Locale-formatted date in parentheses, e.g. "15.5 s (23.04.2026)".
+                // Inline (vs. a separate column) keeps the dialog narrow and avoids
+                // introducing a new translatable column header.
+                best += QStringLiteral("  (") + QLocale().toString(rec.bestDate, QLocale::ShortFormat) + QStringLiteral(")");
+            }
+        }
+        else
+        {
+            best = QStringLiteral("—");
+        }
         const QString winRate = rec.played > 0 ? QStringLiteral(" (%1%)").arg(100 * rec.won / rec.played) : QString{};
         table->setItem(i, 0, new QTableWidgetItem(tr(rows[i].label)));
         table->setItem(i, 1, new QTableWidgetItem(QString::number(rec.played)));

--- a/stats.cpp
+++ b/stats.cpp
@@ -16,6 +16,8 @@ Record load(const QString &difficultyName)
     r.played = settings.value(key(difficultyName, QStringLiteral("played")), 0u).toUInt();
     r.won = settings.value(key(difficultyName, QStringLiteral("won")), 0u).toUInt();
     r.bestSeconds = settings.value(key(difficultyName, QStringLiteral("best_seconds")), 0.0).toDouble();
+    const QString dateStr = settings.value(key(difficultyName, QStringLiteral("best_date")), QString{}).toString();
+    r.bestDate = dateStr.isEmpty() ? QDate{} : QDate::fromString(dateStr, Qt::ISODate);
     return r;
 }
 
@@ -25,6 +27,14 @@ void save(const QString &difficultyName, const Record &r)
     settings.setValue(key(difficultyName, QStringLiteral("played")), r.played);
     settings.setValue(key(difficultyName, QStringLiteral("won")), r.won);
     settings.setValue(key(difficultyName, QStringLiteral("best_seconds")), r.bestSeconds);
+    if (r.bestDate.isValid())
+    {
+        settings.setValue(key(difficultyName, QStringLiteral("best_date")), r.bestDate.toString(Qt::ISODate));
+    }
+    else
+    {
+        settings.remove(key(difficultyName, QStringLiteral("best_date")));
+    }
 }
 
 void reset(const QString &difficultyName)
@@ -33,6 +43,7 @@ void reset(const QString &difficultyName)
     settings.remove(key(difficultyName, QStringLiteral("played")));
     settings.remove(key(difficultyName, QStringLiteral("won")));
     settings.remove(key(difficultyName, QStringLiteral("best_seconds")));
+    settings.remove(key(difficultyName, QStringLiteral("best_date")));
 }
 
 void resetAll()
@@ -50,7 +61,7 @@ void recordLoss(const QString &difficultyName)
     save(difficultyName, r);
 }
 
-bool recordWin(const QString &difficultyName, double seconds)
+bool recordWin(const QString &difficultyName, double seconds, const QDate &onDate)
 {
     Record r = load(difficultyName);
     ++r.played;
@@ -59,6 +70,7 @@ bool recordWin(const QString &difficultyName, double seconds)
     if (newRecord && seconds > 0.0)
     {
         r.bestSeconds = seconds;
+        r.bestDate = onDate;
     }
     save(difficultyName, r);
     return newRecord && seconds > 0.0;

--- a/stats.h
+++ b/stats.h
@@ -1,13 +1,16 @@
 #ifndef STATS_H
 #define STATS_H
 
+#include <QDate>
 #include <QString>
 
 #include <cstdint>
 
 // Per-difficulty lifetime statistics, persisted in QSettings under the
-// stats/<DifficultyName>/{played,won,best_seconds} tree. Best-time is
-// stored as seconds (double); 0 means "no win recorded yet".
+// stats/<DifficultyName>/{played,won,best_seconds,best_date} tree.
+// Best-time is stored as seconds (double); 0 means "no win recorded yet".
+// Best-date is the calendar date (ISO 8601) on which the current best-time
+// run was completed; invalid/empty when no win has been recorded.
 namespace Stats
 {
 struct Record
@@ -15,6 +18,7 @@ struct Record
     std::uint32_t played{0};
     std::uint32_t won{0};
     double bestSeconds{0.0}; // 0 == no record yet
+    QDate bestDate{};        // invalid when no record yet
 };
 
 [[nodiscard]] Record load(const QString &difficultyName);
@@ -28,7 +32,9 @@ void recordLoss(const QString &difficultyName);
 // Convenience: increment Played + Won, and update bestSeconds if the
 // run was faster (or no prior record). Returns true iff a new record
 // was set — so the caller can show a "New record!" flair.
-bool recordWin(const QString &difficultyName, double seconds);
+// `onDate` lets callers (primarily tests) inject the date stamped onto
+// a new best; in production it defaults to today.
+bool recordWin(const QString &difficultyName, double seconds, const QDate &onDate = QDate::currentDate());
 } // namespace Stats
 
 #endif // STATS_H

--- a/tests/tst_stats.cpp
+++ b/tests/tst_stats.cpp
@@ -22,6 +22,15 @@ class TestStats : public QObject
     void testPerDifficultyIsolation();
     void testResetSingle();
     void testResetAllWipesEverything();
+
+    // best-date behaviour
+    void testBestDateInvalidWhenNoWins();
+    void testFirstWinStampsDate();
+    void testFasterWinOverwritesDate();
+    void testSlowerWinKeepsOriginalDate();
+    void testLossDoesNotTouchDate();
+    void testResetWipesDate();
+    void testLegacyRecordWithoutDateLoadsAsInvalid();
 };
 
 void TestStats::initTestCase()
@@ -118,6 +127,72 @@ void TestStats::testResetAllWipesEverything()
     QCOMPARE(Stats::load(QStringLiteral("Beginner")).played, 0u);
     QCOMPARE(Stats::load(QStringLiteral("Intermediate")).played, 0u);
     QCOMPARE(Stats::load(QStringLiteral("Expert")).played, 0u);
+}
+
+void TestStats::testBestDateInvalidWhenNoWins()
+{
+    const auto r = Stats::load(QStringLiteral("Beginner"));
+    QVERIFY(!r.bestDate.isValid());
+}
+
+void TestStats::testFirstWinStampsDate()
+{
+    const QDate d{2026, 4, 23};
+    QVERIFY(Stats::recordWin(QStringLiteral("Beginner"), 30.0, d));
+    const auto r = Stats::load(QStringLiteral("Beginner"));
+    QCOMPARE(r.bestDate, d);
+}
+
+void TestStats::testFasterWinOverwritesDate()
+{
+    const QDate oldDate{2026, 1, 1};
+    const QDate newDate{2026, 4, 23};
+    QVERIFY(Stats::recordWin(QStringLiteral("Beginner"), 30.0, oldDate));
+    QVERIFY(Stats::recordWin(QStringLiteral("Beginner"), 20.0, newDate));
+    QCOMPARE(Stats::load(QStringLiteral("Beginner")).bestDate, newDate);
+}
+
+void TestStats::testSlowerWinKeepsOriginalDate()
+{
+    const QDate originalDate{2026, 1, 1};
+    const QDate laterDate{2026, 4, 23};
+    QVERIFY(Stats::recordWin(QStringLiteral("Beginner"), 20.0, originalDate));
+    QVERIFY(!Stats::recordWin(QStringLiteral("Beginner"), 40.0, laterDate));
+    QCOMPARE(Stats::load(QStringLiteral("Beginner")).bestDate, originalDate);
+}
+
+void TestStats::testLossDoesNotTouchDate()
+{
+    const QDate originalDate{2026, 1, 1};
+    QVERIFY(Stats::recordWin(QStringLiteral("Beginner"), 20.0, originalDate));
+    Stats::recordLoss(QStringLiteral("Beginner"));
+    const auto r = Stats::load(QStringLiteral("Beginner"));
+    QCOMPARE(r.bestDate, originalDate);
+    QCOMPARE(r.played, 2u);
+    QCOMPARE(r.won, 1u);
+}
+
+void TestStats::testResetWipesDate()
+{
+    QVERIFY(Stats::recordWin(QStringLiteral("Beginner"), 20.0, QDate{2026, 1, 1}));
+    Stats::reset(QStringLiteral("Beginner"));
+    QVERIFY(!Stats::load(QStringLiteral("Beginner")).bestDate.isValid());
+}
+
+void TestStats::testLegacyRecordWithoutDateLoadsAsInvalid()
+{
+    // Simulate a pre-1.3 record: played/won/best_seconds keys set, best_date absent.
+    QSettings settings;
+    settings.setValue(QStringLiteral("stats/Beginner/played"), 5u);
+    settings.setValue(QStringLiteral("stats/Beginner/won"), 3u);
+    settings.setValue(QStringLiteral("stats/Beginner/best_seconds"), 42.0);
+    settings.sync();
+
+    const auto r = Stats::load(QStringLiteral("Beginner"));
+    QCOMPARE(r.played, 5u);
+    QCOMPARE(r.won, 3u);
+    QCOMPARE(r.bestSeconds, 42.0);
+    QVERIFY(!r.bestDate.isValid());
 }
 
 QTEST_MAIN(TestStats)


### PR DESCRIPTION
## Summary
- Records the calendar date each lifetime best-time was achieved.
- Shows the date inline after the best time in the **Game → Statistics…** dialog, e.g. `15.5 s  (23.04.2026)`, formatted via `QLocale::ShortFormat`.
- Persists as ISO 8601 under `stats/<diff>/best_date`; legacy records (pre-1.3) load with an invalid date and render as time-only.

## Why
Lifetime records in v1.2.0 had no temporal context. Once you set a Beginner best of 15.5 s, there was no way to know if that was yesterday or three years ago — so the record lost its anchor as a memory of a specific session. This closes that gap with a minimal change.

## Alternatives considered
- **New "Best set on" column** — cleaner typographically, but introduces a new translatable string ("Set on") that would ship English-only to 9 non-en locales until hand-translated. Rejected to respect the project's hand-translations-only policy.
- **Full datetime (date + time of day)** — overkill for a memory anchor; day granularity fits the narrow cell.
- **Separate per-run win log** — bigger scope (new table, new settings keys, migration concerns). Parked.

## API / UX changes
- `Stats::Record` gains `QDate bestDate` (invalid when no win recorded).
- `Stats::recordWin` signature now accepts an optional `onDate` parameter (default `QDate::currentDate()`) for test injection; call sites need no change.
- UI: Statistics dialog's *Best time* cell now shows ` (<short-date>)` after the seconds value when a date is available.

## Backwards compatibility
- Non-breaking. Pre-1.3 `QSettings` payloads (no `best_date` key) load as `QDate{}` and render as time-only. New wins written by 1.3 add the key in place. No migration code, no feature flag needed.

## Rollout / rollback
- Direct rollout — no flag. Rollback = revert the commit; the extra QSettings key is harmless to older binaries (they ignore it).

## Test evidence
- Full suite: `3/3 tests passed, 0 failed` (`tst_minebutton`, `tst_minefield`, `tst_stats`).
- `tst_stats` grew from 11 → 18 tests; 7 new cases cover:
  - `testBestDateInvalidWhenNoWins` — empty-record default
  - `testFirstWinStampsDate` — happy path
  - `testFasterWinOverwritesDate` — new best updates date
  - `testSlowerWinKeepsOriginalDate` — slower run preserves date
  - `testLossDoesNotTouchDate` — loss leaves date alone
  - `testResetWipesDate` — `reset()` clears it
  - `testLegacyRecordWithoutDateLoadsAsInvalid` — boundary: records written by an older binary load cleanly as invalid date
- `clang-format --dry-run --Werror` clean on all touched files.
- Offscreen smoke-test: app launches, Statistics dialog renders without crash on both empty and populated records.

## Assumptions
- Day precision (no hour/minute) — a memory anchor, not an audit trail.
- ISO 8601 persistence / `QLocale::ShortFormat` display.
- Test-injected date (`onDate` parameter) is the correct seam; production defaults to `QDate::currentDate()`.

## Adversarial self-review
- **Backwards compat**: verified by `testLegacyRecordWithoutDateLoadsAsInvalid`.
- **Concurrency**: single-threaded Qt app, no new shared state.
- **Error paths**: `QDate::fromString` on malformed input returns an invalid `QDate`, which the UI handles by showing time-only.
- **Secrets / PII**: date is local-only, never sent to Sentry.
- **Perf**: one extra `settings.value()` read per Statistics dialog open — trivial.

## Test plan
- [x] `ctest --output-on-failure` → 3/3 passed (18 `tst_stats` assertions)
- [x] `clang-format --dry-run --Werror` clean
- [x] Offscreen app launch smoke-test
- [ ] Merge to `main` on green CI and tag `v1.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)