### PR TITLE
feat(v1.9.0): tension smiley during cell hold

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(QMineSweeper
-    VERSION 1.8.0
+    VERSION 1.9.0
     DESCRIPTION "A Qt6-based Minesweeper game"
     HOMEPAGE_URL "https://github.com/Mavrikant/QMineSweeper"
     LANGUAGES CXX

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -116,6 +116,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(std::make_uniq
     connect(ui->mineFieldWidget, &MineField::gameWon, this, &MainWindow::onGameWon);
     connect(ui->mineFieldWidget, &MineField::gameLost, this, &MainWindow::onGameLost);
     connect(ui->mineFieldWidget, &MineField::mineCountChanged, this, [this](int remaining) { ui->mineCount->setNum(remaining); });
+    connect(ui->mineFieldWidget, &MineField::cellInteractionStarted, this, [this] { setSmileyTension(true); });
+    connect(ui->mineFieldWidget, &MineField::cellInteractionEnded, this, [this] { setSmileyTension(false); });
 
     resetTimerUi();
     setWindowTitle(tr("QMineSweeper"));
@@ -573,9 +575,25 @@ void MainWindow::resetTimerUi()
 
 void MainWindow::setSmileyState(GameState state)
 {
+    m_smileyState = state;
+    // A new game / game end always clears any lingering tension flag — the
+    // mouse-release that matched the earlier press may never arrive if the
+    // cell-freeze on win/loss intercepted the event.
+    m_smileyPressing = false;
+    applySmiley();
+}
+
+void MainWindow::setSmileyTension(bool pressing)
+{
+    m_smileyPressing = pressing;
+    applySmiley();
+}
+
+void MainWindow::applySmiley()
+{
     if (ui && ui->smileyButton)
     {
-        ui->smileyButton->setText(smileyForState(state));
+        ui->smileyButton->setText(smileyForTensionState(m_smileyState, m_smileyPressing));
     }
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -45,6 +45,8 @@ class MainWindow : public QMainWindow
     void resetTimerUi();
     void updateTimerLabel();
     void setSmileyState(GameState state);
+    void setSmileyTension(bool pressing);
+    void applySmiley();
     void showEndDialog(bool won, bool newRecord);
     void maybeAskTelemetryConsent();
     void restartApp();
@@ -66,6 +68,8 @@ class MainWindow : public QMainWindow
     double m_lastElapsedSeconds{0.0};
     bool m_isReplay{false};
     bool m_isCustom{false};
+    GameState m_smileyState{GameState::Ready};
+    bool m_smileyPressing{false};
     QString m_releaseId;
 };
 

--- a/minebutton.cpp
+++ b/minebutton.cpp
@@ -241,6 +241,15 @@ void MineButton::mousePressEvent(QMouseEvent *e)
 
     const bool leftAndRight = (e->buttons() & (Qt::LeftButton | Qt::RightButton)) == (Qt::LeftButton | Qt::RightButton);
 
+    // Tension-smiley trigger — fire before any reveal/chord logic so the 😮
+    // face paints while the button is still held, not only after release.
+    // Right-click-only presses are deliberately excluded: flag-cycling should
+    // not change the header indicator.
+    if (e->button() == Qt::LeftButton || e->button() == Qt::MiddleButton || leftAndRight)
+    {
+        emit pressStart();
+    }
+
     if (e->button() == Qt::MiddleButton || leftAndRight)
     {
         if (m_isClicked)
@@ -264,4 +273,13 @@ void MineButton::mousePressEvent(QMouseEvent *e)
     default:
         break;
     }
+}
+
+void MineButton::mouseReleaseEvent(QMouseEvent *e)
+{
+    Q_UNUSED(e);
+    // Always emit on release — MainWindow tracks tension with a single flag,
+    // so an unmatched pressEnd (e.g. after a right-click-only press that never
+    // emitted pressStart) is a harmless no-op.
+    emit pressEnd();
 }

--- a/minebutton.h
+++ b/minebutton.h
@@ -54,9 +54,16 @@ class MineButton : public QPushButton
     // and does NOT fire again when it returns to None from Question.
     void flagToggled(std::uint32_t row, std::uint32_t col, bool flagged);
     void chordRequested(std::uint32_t row, std::uint32_t col);
+    // Fires while a left/middle/chord mouse button is held down on the cell
+    // (before any reveal/chord is processed). Right-click-only presses do not
+    // fire pressStart — they just cycle the marker without any hold feedback.
+    // MainWindow uses these to drive the classic 😮 "tension" smiley.
+    void pressStart();
+    void pressEnd();
 
   protected:
     void mousePressEvent(QMouseEvent *e) override;
+    void mouseReleaseEvent(QMouseEvent *e) override;
 
   private:
     void cycleMarker();

--- a/minefield.cpp
+++ b/minefield.cpp
@@ -155,6 +155,8 @@ void MineField::wireButton(MineButton *button)
     connect(button, &MineButton::checkNeighbours, this, &MineField::onCheckNeighbours);
     connect(button, &MineButton::flagToggled, this, &MineField::onFlagToggled);
     connect(button, &MineButton::chordRequested, this, &MineField::onChordRequested);
+    connect(button, &MineButton::pressStart, this, &MineField::cellInteractionStarted);
+    connect(button, &MineButton::pressEnd, this, &MineField::cellInteractionEnded);
 }
 
 void MineField::fillMines(std::uint32_t safeRow, std::uint32_t safeCol)

--- a/minefield.h
+++ b/minefield.h
@@ -73,6 +73,11 @@ class MineField : public QWidget
     void gameWon();
     void gameLost(std::uint32_t row, std::uint32_t col);
     void mineCountChanged(int remaining);
+    // Forwarded from MineButton::pressStart/pressEnd so MainWindow can drive
+    // the tension smiley without needing per-cell wiring. Cell-agnostic on
+    // purpose — the indicator doesn't care which cell is being held.
+    void cellInteractionStarted();
+    void cellInteractionEnded();
 
   private slots:
     void onCellPressed(std::uint32_t row, std::uint32_t col);

--- a/smiley.h
+++ b/smiley.h
@@ -24,4 +24,17 @@ inline QString smileyForState(GameState state)
     return QStringLiteral("🙂");
 }
 
+// Tension-aware variant: while a cell is held down during Ready/Playing, the
+// classic Minesweeper clones show a 😮 "holding my breath" face. Won/Lost
+// states override tension — once the game is over, the cells are frozen and
+// the indicator should stay on its final face.
+inline QString smileyForTensionState(GameState state, bool pressing)
+{
+    if (pressing && (state == GameState::Ready || state == GameState::Playing))
+    {
+        return QStringLiteral("😮");
+    }
+    return smileyForState(state);
+}
+
 #endif // SMILEY_H

--- a/tests/tst_minebutton.cpp
+++ b/tests/tst_minebutton.cpp
@@ -31,6 +31,11 @@ class TestMineButton : public QObject
     void testLeftClickBlockedByFlagNotByQuestion();
     void testQuestionMarksDisabledSkipsQuestion();
     void testClearQuestionResetsMarker();
+    void testLeftPressEmitsPressStart();
+    void testRightPressDoesNotEmitPressStart();
+    void testMiddlePressEmitsPressStart();
+    void testMouseReleaseEmitsPressEnd();
+    void testDisabledCellEmitsNoPressSignals();
     void cleanup();
 };
 
@@ -38,6 +43,12 @@ static void sendMouseClick(MineButton &btn, Qt::MouseButton button)
 {
     QMouseEvent press(QEvent::MouseButtonPress, QPointF(5, 5), QPointF(5, 5), button, button, Qt::NoModifier);
     QCoreApplication::sendEvent(&btn, &press);
+}
+
+static void sendMouseRelease(MineButton &btn, Qt::MouseButton button)
+{
+    QMouseEvent release(QEvent::MouseButtonRelease, QPointF(5, 5), QPointF(5, 5), button, Qt::NoButton, Qt::NoModifier);
+    QCoreApplication::sendEvent(&btn, &release);
 }
 
 void TestMineButton::testInitialState()
@@ -297,6 +308,53 @@ void TestMineButton::testClearQuestionResetsMarker()
     QSignalSpy openedSpy(&btn, &MineButton::cellOpened);
     sendMouseClick(btn, Qt::LeftButton);
     QCOMPARE(openedSpy.count(), 1);
+}
+
+void TestMineButton::testLeftPressEmitsPressStart()
+{
+    MineButton btn(0, 0, nullptr);
+    QSignalSpy startSpy(&btn, &MineButton::pressStart);
+    sendMouseClick(btn, Qt::LeftButton);
+    QCOMPARE(startSpy.count(), 1);
+}
+
+void TestMineButton::testRightPressDoesNotEmitPressStart()
+{
+    // Flag-only clicks must NOT trigger the tension smiley — only cells that
+    // could actually be revealed (or chorded) contribute to the hold state.
+    MineButton btn(0, 0, nullptr);
+    QSignalSpy startSpy(&btn, &MineButton::pressStart);
+    sendMouseClick(btn, Qt::RightButton);
+    QCOMPARE(startSpy.count(), 0);
+}
+
+void TestMineButton::testMiddlePressEmitsPressStart()
+{
+    MineButton btn(0, 0, nullptr);
+    QSignalSpy startSpy(&btn, &MineButton::pressStart);
+    sendMouseClick(btn, Qt::MiddleButton);
+    QCOMPARE(startSpy.count(), 1);
+}
+
+void TestMineButton::testMouseReleaseEmitsPressEnd()
+{
+    MineButton btn(0, 0, nullptr);
+    QSignalSpy endSpy(&btn, &MineButton::pressEnd);
+    sendMouseClick(btn, Qt::LeftButton);
+    QCOMPARE(endSpy.count(), 0);
+    sendMouseRelease(btn, Qt::LeftButton);
+    QCOMPARE(endSpy.count(), 1);
+}
+
+void TestMineButton::testDisabledCellEmitsNoPressSignals()
+{
+    // Frozen cells (post-win/loss) must not emit tension signals — otherwise
+    // a stray click on a dead board would flip the indicator away from 😎/😵.
+    MineButton btn(0, 0, nullptr);
+    btn.setCellEnabled(false);
+    QSignalSpy startSpy(&btn, &MineButton::pressStart);
+    sendMouseClick(btn, Qt::LeftButton);
+    QCOMPARE(startSpy.count(), 0);
 }
 
 void TestMineButton::cleanup()

--- a/tests/tst_smiley.cpp
+++ b/tests/tst_smiley.cpp
@@ -2,6 +2,8 @@
 #include "../minefield.h"
 #include "../smiley.h"
 
+#include <QCoreApplication>
+#include <QMouseEvent>
 #include <QPushButton>
 #include <QtTest>
 
@@ -16,6 +18,9 @@ class TestSmiley : public QObject
     void testLostFace();
     void testAllFacesAreDistinctExceptReadyPlaying();
     void testIntegrationWithMineFieldSignals();
+    void testTensionFaceWhilePressing();
+    void testTensionIgnoredAfterGameOver();
+    void testPressReleaseDrivesTension();
 };
 
 void TestSmiley::testReadyFace() { QCOMPARE(smileyForState(GameState::Ready), QStringLiteral("🙂")); }
@@ -70,6 +75,83 @@ void TestSmiley::testIntegrationWithMineFieldSignals()
     field.cellAt(0, 0)->Open();
     QCOMPARE(field.state(), GameState::Lost);
     QCOMPARE(button.text(), QStringLiteral("😵"));
+}
+
+void TestSmiley::testTensionFaceWhilePressing()
+{
+    // While a cell is held down in Ready or Playing, the indicator flips to
+    // the classic 😮 "holding my breath" face.
+    QCOMPARE(smileyForTensionState(GameState::Ready, true), QStringLiteral("😮"));
+    QCOMPARE(smileyForTensionState(GameState::Playing, true), QStringLiteral("😮"));
+    // Not pressing — falls back to the plain state face.
+    QCOMPARE(smileyForTensionState(GameState::Ready, false), QStringLiteral("🙂"));
+    QCOMPARE(smileyForTensionState(GameState::Playing, false), QStringLiteral("🙂"));
+}
+
+void TestSmiley::testTensionIgnoredAfterGameOver()
+{
+    // After win/loss the cells are frozen, so any lingering "pressing" flag
+    // must not override the final 😎/😵 — the indicator should stay put.
+    QCOMPARE(smileyForTensionState(GameState::Won, true), QStringLiteral("😎"));
+    QCOMPARE(smileyForTensionState(GameState::Lost, true), QStringLiteral("😵"));
+    QCOMPARE(smileyForTensionState(GameState::Won, false), QStringLiteral("😎"));
+    QCOMPARE(smileyForTensionState(GameState::Lost, false), QStringLiteral("😵"));
+}
+
+void TestSmiley::testPressReleaseDrivesTension()
+{
+    // Full wiring: MineButton press/release → MineField forwards →
+    // button text flips between 🙂 and 😮 for left-click, and stays on 🙂 for
+    // right-click (flag-only presses must not trigger tension).
+    MineField field;
+    field.setFixedLayout(3, 3, {{0, 0}});
+    GameState lastState = GameState::Ready;
+    bool pressing = false;
+    QPushButton button;
+    const auto refresh = [&] { button.setText(smileyForTensionState(lastState, pressing)); };
+    refresh();
+
+    QObject::connect(&field, &MineField::gameStarted, &button,
+                     [&]
+                     {
+                         lastState = GameState::Playing;
+                         refresh();
+                     });
+    QObject::connect(&field, &MineField::cellInteractionStarted, &button,
+                     [&]
+                     {
+                         pressing = true;
+                         refresh();
+                     });
+    QObject::connect(&field, &MineField::cellInteractionEnded, &button,
+                     [&]
+                     {
+                         pressing = false;
+                         refresh();
+                     });
+
+    auto *cell = field.cellAt(1, 1);
+    QVERIFY(cell != nullptr);
+
+    // Left-click: press → tension. Release → tension off, state=Playing.
+    QCOMPARE(button.text(), QStringLiteral("🙂"));
+    QMouseEvent press(QEvent::MouseButtonPress, QPointF(5, 5), QPointF(5, 5), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QCoreApplication::sendEvent(cell, &press);
+    QCOMPARE(button.text(), QStringLiteral("😮"));
+    QMouseEvent release(QEvent::MouseButtonRelease, QPointF(5, 5), QPointF(5, 5), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    QCoreApplication::sendEvent(cell, &release);
+    QCOMPARE(button.text(), QStringLiteral("🙂"));
+    QCOMPARE(field.state(), GameState::Playing);
+
+    // Right-click on an un-opened neighbour: no tension at any point.
+    auto *neighbour = field.cellAt(2, 2);
+    QVERIFY(neighbour != nullptr);
+    QMouseEvent rpress(QEvent::MouseButtonPress, QPointF(5, 5), QPointF(5, 5), Qt::RightButton, Qt::RightButton, Qt::NoModifier);
+    QCoreApplication::sendEvent(neighbour, &rpress);
+    QCOMPARE(button.text(), QStringLiteral("🙂"));
+    QMouseEvent rrelease(QEvent::MouseButtonRelease, QPointF(5, 5), QPointF(5, 5), Qt::RightButton, Qt::NoButton, Qt::NoModifier);
+    QCoreApplication::sendEvent(neighbour, &rrelease);
+    QCOMPARE(button.text(), QStringLiteral("🙂"));
 }
 
 QTEST_MAIN(TestSmiley)


### PR DESCRIPTION
## Summary

Adds the classic Minesweeper "tension" face (😮) to the status smiley
while a cell is held down during an active game. Mirrors Windows
Minesweeper, Minesweeper Arbiter, and GNOME Mines — one of the last
bits of iconic Minesweeper feedback this clone was missing. Direct
follow-on to v1.8.0's smiley indicator; v1.8.0's cycle log flagged
this explicitly as a next-candidate.

### Behavior

- Left-click press on any cell → 😮. Release → back to the current
  state's face (🙂 / 😎 / 😵).
- Middle-click or left+right chord → same tension on press, reverts
  on release.
- Right-click press (flag cycling) → **no** tension. Flagging is a
  "mark it and move on" gesture; neither the reference clones nor
  users expect the indicator to flicker.
- After win/loss the cells are frozen; stray release events from
  mid-click transitions can't strand the indicator on 😮 —
  `smileyForTensionState()` makes Won/Lost authoritative, and
  `setSmileyState()` also clears the tension flag on every transition.

## Design

- **`MineButton::pressStart()` / `pressEnd()`** are new signals, cell
  agnostic on purpose — the indicator doesn't care which cell.
  `mousePressEvent` fires `pressStart` before the reveal/chord branch
  (so painting happens during the hold, not after release). A new
  `mouseReleaseEvent` override fires `pressEnd` always — MainWindow
  tracks tension with a single bool, so an unmatched end is a no-op.
- **`MineField` forwards** as `cellInteractionStarted` /
  `cellInteractionEnded`. Kept cell-agnostic so MainWindow doesn't
  need per-cell plumbing.
- **`smileyForTensionState(GameState, bool pressing)`** lives in
  `smiley.h` as an inline pure function, same precedent as v1.8.0's
  `smileyForState()`. Testable in isolation; Won/Lost override tension.
- **`MainWindow::applySmiley()`** is the new single source of truth;
  `setSmileyState(state)` and `setSmileyTension(active)` both route
  through it. `setSmileyState` also resets the tension flag — a win
  reached through a chord-and-release race shouldn't leave 😮 stuck.

### Alternatives considered

- *Overlap press/release with `cellPressed`.* Rejected — `cellPressed`
  fires only when `Open()` actually reveals a cell, and not for chord
  interactions or flagged cells. Tension UX wants "any mouse-down that
  could affect the grid", which is a different cut.
- *Event filter on MineField instead of per-button signals.* Rejected
  — would break the existing signals-up/slots-down invariant called
  out in CLAUDE.md ("No back-pointer to MineField: signals up, slots
  down"). Adding two signals on MineButton is the idiomatic extension.

### Test evidence

Full suite green on Ninja/Qt 6.11 / macOS arm64:

\`\`\`
1/4 Test #1: tst_minebutton ...................   Passed    0.66 sec
2/4 Test #2: tst_minefield ....................   Passed    0.50 sec
3/4 Test #3: tst_stats ........................   Passed    0.38 sec
4/4 Test #4: tst_smiley .......................   Passed    0.40 sec
100% tests passed, 0 tests failed out of 4
\`\`\`

New coverage:
- `TestSmiley::testTensionFaceWhilePressing` — Ready/Playing + pressing → 😮.
- `TestSmiley::testTensionIgnoredAfterGameOver` — pressing flag cannot override 😎/😵.
- `TestSmiley::testPressReleaseDrivesTension` — end-to-end: real `MineField`, dispatched `QMouseEvent` press + release to a cell; button text transitions 🙂 → 😮 → 🙂; right-click-only press stays 🙂.
- `TestMineButton::testLeftPressEmitsPressStart` / `testRightPressDoesNotEmitPressStart` / `testMiddlePressEmitsPressStart` / `testMouseReleaseEmitsPressEnd` / `testDisabledCellEmitsNoPressSignals`.

### Translation / compat

- Zero new `tr()` strings. 😮 is a Unicode glyph, proven to render on the same font-fallback stacks that already carry 🏆/🙂/😎/😵. 58/58 finished preserved per locale.
- Pure UI addition. No settings, no telemetry, no schema. Existing
  keybindings/menus/behavior unchanged.

## Test plan

- [x] `ctest` green locally (4/4)
- [x] `clang-format --dry-run --Werror *.cpp *.h tests/*.cpp` clean
- [ ] ubuntu / windows / macos CI
- [ ] codecov + formatter + codefactor