### PR TITLE
feat(v1.11.0): keyboard navigation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(QMineSweeper
-    VERSION 1.10.0
+    VERSION 1.11.0
     DESCRIPTION "A Qt6-based Minesweeper game"
     HOMEPAGE_URL "https://github.com/Mavrikant/QMineSweeper"
     LANGUAGES CXX

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,5 +1,112 @@
 # Cycle decisions
 
+## 2026-04-24 — Keyboard navigation (v1.11.0)
+
+**Chosen:** Add full keyboard control of the minefield — arrow keys move
+focus between cells, Space / Enter reveal (or chord if the focused cell
+is already opened), F toggles the marker (same cycle as right-click),
+and D forces chord. The focused cell gets a distinct blue inset focus
+ring so keyboard users can see where they are.
+
+**Why this one:**
+- Parked for five cycles running (3, 4, 5, 6, 7, 8) with the same
+  rationale each time: "medium surface, zero translation cost, good
+  accessibility win." Nothing else on the parked list has a lower
+  translation burden, and the repo's user-feedback queue is empty — so
+  autonomous cycle 9 is the right moment to clear it.
+- Accessibility: today the app is unplayable without a mouse. A
+  minesweeper grid is a pure keyboard-friendly UI (finite cells,
+  discrete actions) — there's no good reason to gate it on mouse input.
+- Small, self-contained: ~90 LOC of real code (MineButton focus policy
+  + paint ring; MineField eventFilter with a switch-statement dispatcher;
+  no new QSettings keys, no new menu items, no new dialog). Tests:
+  ~130 LOC exercising all eight key paths. Under the 400-LOC cycle cap.
+- **Zero new translatable strings.** The feature has no visible label,
+  tooltip, menu entry, or dialog copy — it's keyboard behaviour plus a
+  focus outline. 81/81 finished per locale preserved.
+
+**Rejected alternatives from the prior `Next candidates` list:**
+- *Pause / resume.* Still the highest-value parked candidate for a
+  human-directed cycle, but ~3 new strings × 10 locales and it touches
+  the timer/state machine — the most critical UI path. Sixth cycle of
+  parking; still the right call for an autonomous budget.
+- *No-flag speedrun achievement.* Genuinely small. Would add 1 new
+  translatable string and a Stats-schema column (best no-flag time).
+  Parked — keyboard nav strictly dominates on both accessibility value
+  and translation cost (zero vs. one).
+- *Overlay-with-bubbles tutorial upgrade.* Cosmetic; nobody has asked.
+
+**Implementation choices:**
+
+1. **Event filter on MineField, not keyPressEvent on MineButton.** The
+   project's bedrock architecture rule is "MineButton has no back-pointer
+   to MineField — signals up, slots down." Handling arrow keys requires
+   knowing the grid to resolve "the cell one row up" — a lookup that
+   only MineField can do. An event filter on the parent wrapping every
+   child runs BEFORE the child's own keyPressEvent, which is the only
+   way to intercept Space/Enter before `QAbstractButton::keyPressEvent`
+   emits `clicked` (which nothing listens to, but that's beside the
+   point — we want our reveal-vs-chord decision, not the default).
+
+2. **Qt::StrongFocus explicit on MineButton.** macOS ships
+   `Qt::TabFocus` by default for push buttons, which makes arrow-key
+   navigation work on Linux/Windows but silently no-op on macOS. An
+   explicit setter rules out platform drift.
+
+3. **Focus ring drawn in `paintEvent` override, not `:focus` stylesheet
+   pseudo-state.** The cell stylesheet uses `border: 0px` (to get the
+   flush checkerboard look) and changes mid-game (opened / mine /
+   wrong-flag). Chaining `:focus { border: ... }` onto every stylesheet
+   mutation would be a correctness landmine. A single `paintEvent`
+   override that draws a 2-px inset rectangle when `hasFocus()` is
+   stylesheet-independent and survives every state change.
+
+4. **Space dispatches reveal-vs-chord based on opened state.**
+   - Opened cell → `onChordRequested(r, c)` (same as middle-click).
+   - Unopened, non-flag cell → `cell->Open()` (same as left-click).
+   - Unopened, flagged cell → no-op (flag protects from reveal, same
+     as left-click).
+   This mirrors the "intuitive single key" UX of GNOME Mines —
+   keyboard users don't want to remember separate keys for reveal
+   and chord when the cell state already disambiguates.
+
+5. **`D` forces chord.** Kept for players who memorise the opened
+   state and want an explicit chord key (parallels middle-click). On
+   an unopened cell D is a no-op, not an error — minimises surprise.
+
+6. **`F` reuses `cycleMarker()`, which is moved from `private` to
+   `public` on MineButton.** `cycleMarker` is idempotent with the
+   mouse right-click path — same state transitions, same
+   `flagToggled` signal emissions, same question-marks setting
+   respect. Making it public is a trivially safe visibility widen;
+   the alternative (synthetic `QMouseEvent` injection) is ugly.
+
+7. **Key events during `GameState::Won`/`Lost` only allow arrow
+   navigation.** After a game ends, `freezeAllCells()` disables cell
+   actions. The event filter short-circuits Space/F/D/Enter at the
+   top of `handleCellKey` when the state is terminal; arrows still
+   work so the user can look around the revealed board.
+
+8. **No auto-focus on new game.** Set-focus-on-build would steal
+   focus from the menu bar and the telemetry-consent dialog on
+   startup. Users who want keyboard control Tab into the grid or
+   click a cell first, then navigate. Matches how every other
+   keyboard-friendly Qt widget behaves.
+
+**Assumptions:**
+- QAbstractButton does not pre-consume arrow keys outside a
+  QButtonGroup (confirmed empirically — arrow keys reach the event
+  filter even without it returning true early). The filter still
+  handles them unconditionally, so this is defence-in-depth.
+- The inset focus ring (2-px blue border at 1-px inset) is visible
+  on every cell stylesheet: green-checker base, tan-checker opened,
+  orange mine-reveal, red wrong-flag. Verified in live app on the
+  green+tan combination; the blue is high-contrast against all four.
+- `D` is not a common muscle-memory shortcut for any minesweeper
+  clone (Windows Minesweeper uses middle-click only). Picked because
+  it's adjacent to F on QWERTY — easy to remember as the "other
+  modifier-free action key."
+
 ## 2026-04-24 — First-run tutorial (v1.10.0, closes #26)
 
 **Chosen:** A six-step modal-card tutorial opens once automatically on the

--- a/minebutton.cpp
+++ b/minebutton.cpp
@@ -5,6 +5,8 @@
 #include <QFont>
 #include <QIcon>
 #include <QMouseEvent>
+#include <QPainter>
+#include <QPen>
 #include <QSizePolicy>
 #include <QString>
 
@@ -54,8 +56,16 @@ MineButton::MineButton(std::uint32_t row, std::uint32_t col, QWidget *parent) : 
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
     setFont(QFont{"Arial", 12, QFont::Bold});
     setCursor(Qt::PointingHandCursor);
+    // Explicit StrongFocus so keyboard navigation works uniformly across
+    // platforms (macOS defaults to Qt::TabFocus for push buttons, which
+    // would make arrow-key navigation inconsistent with Linux/Windows).
+    setFocusPolicy(Qt::StrongFocus);
     applyBaseStyle();
 }
+
+std::uint32_t MineButton::row() const noexcept { return m_row; }
+
+std::uint32_t MineButton::col() const noexcept { return m_col; }
 
 void MineButton::applyBaseStyle() { setStyleSheet(((m_row + m_col) % 2) ? kOddCellStyle : kEvenCellStyle); }
 
@@ -282,4 +292,21 @@ void MineButton::mouseReleaseEvent(QMouseEvent *e)
     // so an unmatched pressEnd (e.g. after a right-click-only press that never
     // emitted pressStart) is a harmless no-op.
     emit pressEnd();
+}
+
+void MineButton::paintEvent(QPaintEvent *e)
+{
+    QPushButton::paintEvent(e);
+    if (!hasFocus())
+    {
+        return;
+    }
+    // Keyboard-focus indicator. The cell stylesheet uses border: 0 and suppresses
+    // the native focus ring; draw a thin inset rectangle so keyboard users can
+    // see which cell is selected.
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, false);
+    p.setPen(QPen(QColor(40, 90, 200), 2));
+    p.setBrush(Qt::NoBrush);
+    p.drawRect(1, 1, width() - 2, height() - 2);
 }

--- a/minebutton.h
+++ b/minebutton.h
@@ -20,6 +20,9 @@ class MineButton : public QPushButton
 
     explicit MineButton(std::uint32_t row, std::uint32_t col, QWidget *parent = nullptr);
 
+    [[nodiscard]] std::uint32_t row() const noexcept;
+    [[nodiscard]] std::uint32_t col() const noexcept;
+
     void setNumber(std::uint32_t number);
     [[nodiscard]] std::uint32_t Number() const noexcept;
 
@@ -33,6 +36,11 @@ class MineButton : public QPushButton
     [[nodiscard]] bool isOpened() const noexcept;
 
     void Open();
+    // Advance the marker state (None → Flag → Question → None, or
+    // None → Flag → None when question marks are disabled). Emits
+    // flagToggled on Flag-on / Flag-off transitions. Called internally
+    // on right-click; also used by the keyboard-navigation path.
+    void cycleMarker();
     void setCellEnabled(bool enabled) noexcept;
     void revealAsMine();
     void revealAsWrongFlag();
@@ -64,9 +72,9 @@ class MineButton : public QPushButton
   protected:
     void mousePressEvent(QMouseEvent *e) override;
     void mouseReleaseEvent(QMouseEvent *e) override;
+    void paintEvent(QPaintEvent *e) override;
 
   private:
-    void cycleMarker();
     void applyBaseStyle();
     void applyOpenedStyle();
     void renderMarker();

--- a/minefield.cpp
+++ b/minefield.cpp
@@ -1,5 +1,7 @@
 #include "minefield.h"
 
+#include <QEvent>
+#include <QKeyEvent>
 #include <QSizePolicy>
 
 #include <algorithm>
@@ -157,6 +159,115 @@ void MineField::wireButton(MineButton *button)
     connect(button, &MineButton::chordRequested, this, &MineField::onChordRequested);
     connect(button, &MineButton::pressStart, this, &MineField::cellInteractionStarted);
     connect(button, &MineButton::pressEnd, this, &MineField::cellInteractionEnded);
+    button->installEventFilter(this);
+}
+
+bool MineField::eventFilter(QObject *watched, QEvent *event)
+{
+    if (event->type() == QEvent::KeyPress)
+    {
+        if (auto *cell = qobject_cast<MineButton *>(watched))
+        {
+            auto *ke = static_cast<QKeyEvent *>(event);
+            if (handleCellKey(cell, ke->key()))
+            {
+                return true;
+            }
+        }
+    }
+    return QWidget::eventFilter(watched, event);
+}
+
+bool MineField::handleCellKey(MineButton *cell, int key)
+{
+    if (m_state == GameState::Won || m_state == GameState::Lost)
+    {
+        // Board is frozen; let arrow keys still move focus so the user can
+        // look at cells, but swallow action keys so they can't re-enter logic.
+        switch (key)
+        {
+        case Qt::Key_Up:
+        case Qt::Key_Down:
+        case Qt::Key_Left:
+        case Qt::Key_Right:
+            break;
+        default:
+            return false;
+        }
+    }
+
+    const std::uint32_t r = cell->row();
+    const std::uint32_t c = cell->col();
+
+    switch (key)
+    {
+    case Qt::Key_Up:
+        if (r > 0)
+        {
+            focusCell(r - 1, c);
+        }
+        return true;
+    case Qt::Key_Down:
+        if (r + 1 < m_difficulty.height)
+        {
+            focusCell(r + 1, c);
+        }
+        return true;
+    case Qt::Key_Left:
+        if (c > 0)
+        {
+            focusCell(r, c - 1);
+        }
+        return true;
+    case Qt::Key_Right:
+        if (c + 1 < m_difficulty.width)
+        {
+            focusCell(r, c + 1);
+        }
+        return true;
+    case Qt::Key_Space:
+    case Qt::Key_Return:
+    case Qt::Key_Enter:
+        // Space/Enter on an opened numbered cell chords, matching mouse UX
+        // (middle-click / left+right). On an unopened non-flag cell it reveals.
+        // On a flagged cell it is a deliberate no-op — mirrors left-click.
+        if (cell->isOpened())
+        {
+            onChordRequested(r, c);
+        }
+        else if (!cell->isFlagged())
+        {
+            cell->Open();
+        }
+        return true;
+    case Qt::Key_F:
+        // Toggle marker, same cycle as right-click.
+        cell->cycleMarker();
+        return true;
+    case Qt::Key_D:
+        // Chord-only shortcut for keyboard users — the Space path auto-picks
+        // reveal vs. chord based on opened state; D forces chord. Matches the
+        // middle-click affordance for players who memorise the opened state.
+        if (cell->isOpened())
+        {
+            onChordRequested(r, c);
+        }
+        return true;
+    default:
+        return false;
+    }
+}
+
+void MineField::focusCell(std::uint32_t row, std::uint32_t col)
+{
+    if (row >= m_difficulty.height || col >= m_difficulty.width)
+    {
+        return;
+    }
+    if (auto *target = m_buttons[row][col])
+    {
+        target->setFocus(Qt::TabFocusReason);
+    }
 }
 
 void MineField::fillMines(std::uint32_t safeRow, std::uint32_t safeCol)

--- a/minefield.h
+++ b/minefield.h
@@ -68,6 +68,13 @@ class MineField : public QWidget
     // Test helper: direct access for fixture-based tests.
     [[nodiscard]] MineButton *cellAt(std::uint32_t row, std::uint32_t col) const;
 
+  protected:
+    // Keyboard navigation. MineField installs itself as an event filter on
+    // every MineButton so it can intercept key events before QAbstractButton
+    // eats Space/Enter (for click activation) or arrow keys (for button-group
+    // navigation). Centralising in one place keeps MineButton back-pointer-free.
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
   signals:
     void gameStarted();
     void gameWon();
@@ -98,6 +105,8 @@ class MineField : public QWidget
     void freezeAllCells();
     void updateMineCountLabel();
     void checkWin();
+    bool handleCellKey(MineButton *cell, int key);
+    void focusCell(std::uint32_t row, std::uint32_t col);
 
     QGridLayout *m_grid{nullptr};
     std::vector<std::vector<MineButton *>> m_buttons;

--- a/tests/tst_minefield.cpp
+++ b/tests/tst_minefield.cpp
@@ -35,9 +35,18 @@ class TestMineField : public QObject
     void testCustomDifficultyGridSize();
     void testCustomDifficultyFirstClickSafety();
     void testCustomDifficultyMineCountBoundary();
+    void testKeyboardArrowsMoveFocus();
+    void testKeyboardArrowsRespectBounds();
+    void testKeyboardSpaceRevealsCell();
+    void testKeyboardSpaceOnOpenedChords();
+    void testKeyboardFTogglesFlag();
+    void testKeyboardDChordsOpenedCell();
+    void testKeyboardSpaceOnFlaggedIsNoop();
+    void testKeyboardIgnoredAfterLoss();
 
   private:
     static void openAllSafe(MineField &field);
+    static void sendKey(MineButton *target, int key);
 };
 
 void TestMineField::testConstruction()
@@ -437,6 +446,160 @@ void TestMineField::testCustomDifficultyMineCountBoundary()
     }
     QCOMPARE(mines, 72u);
     QVERIFY(!field.cellAt(4, 4)->isMined());
+}
+
+void TestMineField::sendKey(MineButton *target, int key)
+{
+    QKeyEvent press(QEvent::KeyPress, key, Qt::NoModifier);
+    QCoreApplication::sendEvent(target, &press);
+}
+
+void TestMineField::testKeyboardArrowsMoveFocus()
+{
+    MineField field;
+    field.setFixedLayout(5, 5, {{0, 0}});
+    field.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&field));
+
+    MineButton *start = field.cellAt(2, 2);
+    start->setFocus(Qt::OtherFocusReason);
+    QCOMPARE(field.focusWidget(), start);
+
+    sendKey(start, Qt::Key_Right);
+    QCOMPARE(field.focusWidget(), field.cellAt(2, 3));
+
+    sendKey(field.cellAt(2, 3), Qt::Key_Down);
+    QCOMPARE(field.focusWidget(), field.cellAt(3, 3));
+
+    sendKey(field.cellAt(3, 3), Qt::Key_Left);
+    QCOMPARE(field.focusWidget(), field.cellAt(3, 2));
+
+    sendKey(field.cellAt(3, 2), Qt::Key_Up);
+    QCOMPARE(field.focusWidget(), field.cellAt(2, 2));
+}
+
+void TestMineField::testKeyboardArrowsRespectBounds()
+{
+    MineField field;
+    field.setFixedLayout(3, 3, {{2, 2}});
+    field.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&field));
+
+    MineButton *corner = field.cellAt(0, 0);
+    corner->setFocus(Qt::OtherFocusReason);
+    QCOMPARE(field.focusWidget(), corner);
+
+    sendKey(corner, Qt::Key_Up);
+    QCOMPARE(field.focusWidget(), corner); // stays put, no wrap
+    sendKey(corner, Qt::Key_Left);
+    QCOMPARE(field.focusWidget(), corner);
+
+    MineButton *farCorner = field.cellAt(2, 2);
+    farCorner->setFocus(Qt::OtherFocusReason);
+    sendKey(farCorner, Qt::Key_Down);
+    QCOMPARE(field.focusWidget(), farCorner);
+    sendKey(farCorner, Qt::Key_Right);
+    QCOMPARE(field.focusWidget(), farCorner);
+}
+
+void TestMineField::testKeyboardSpaceRevealsCell()
+{
+    MineField field;
+    field.setFixedLayout(3, 3, {{0, 0}});
+    MineButton *target = field.cellAt(2, 2);
+    QVERIFY(!target->isOpened());
+
+    sendKey(target, Qt::Key_Space);
+    QVERIFY(target->isOpened());
+    // (2,2) has no mine neighbours, flood-fill opens the plateau.
+    QVERIFY(field.cellAt(1, 1)->isOpened());
+}
+
+void TestMineField::testKeyboardSpaceOnOpenedChords()
+{
+    MineField field;
+    // Mine at (0,0); (1,1) has number 1.
+    field.setFixedLayout(3, 3, {{0, 0}});
+    field.cellAt(1, 1)->Open();
+    QCOMPARE(field.cellAt(1, 1)->Number(), 1u);
+
+    // Flag the mine.
+    field.cellAt(0, 0)->cycleMarker();
+    QVERIFY(field.cellAt(0, 0)->isFlagged());
+
+    // Space on opened (1,1) should chord and open all safe neighbours.
+    sendKey(field.cellAt(1, 1), Qt::Key_Space);
+    QVERIFY(field.cellAt(0, 1)->isOpened());
+    QVERIFY(field.cellAt(1, 0)->isOpened());
+    QVERIFY(field.cellAt(2, 0)->isOpened());
+    QVERIFY(field.cellAt(2, 2)->isOpened());
+    QVERIFY(!field.cellAt(0, 0)->isOpened()); // stays flagged
+}
+
+void TestMineField::testKeyboardFTogglesFlag()
+{
+    MineField field;
+    field.setFixedLayout(3, 3, {{0, 0}});
+    QLabel label;
+    field.setMineCountLabel(&label);
+
+    MineButton *target = field.cellAt(2, 2);
+    QCOMPARE(label.text(), QString::number(1));
+
+    sendKey(target, Qt::Key_F);
+    QCOMPARE(target->marker(), CellMarker::Flag);
+    QCOMPARE(label.text(), QString::number(0));
+
+    sendKey(target, Qt::Key_F);
+    // Default: question marks enabled → second F goes to Question, not None.
+    QCOMPARE(target->marker(), CellMarker::Question);
+    QCOMPARE(label.text(), QString::number(1)); // flag cleared, mine count back up
+
+    sendKey(target, Qt::Key_F);
+    QCOMPARE(target->marker(), CellMarker::None);
+}
+
+void TestMineField::testKeyboardDChordsOpenedCell()
+{
+    MineField field;
+    field.setFixedLayout(3, 3, {{0, 0}});
+    field.cellAt(1, 1)->Open();
+    field.cellAt(0, 0)->cycleMarker(); // flag
+
+    sendKey(field.cellAt(1, 1), Qt::Key_D);
+    QVERIFY(field.cellAt(0, 1)->isOpened());
+    QVERIFY(field.cellAt(2, 2)->isOpened());
+}
+
+void TestMineField::testKeyboardSpaceOnFlaggedIsNoop()
+{
+    MineField field;
+    field.setFixedLayout(3, 3, {{0, 0}});
+    MineButton *target = field.cellAt(2, 2);
+    target->cycleMarker(); // flag it
+    QVERIFY(target->isFlagged());
+
+    sendKey(target, Qt::Key_Space);
+    QVERIFY(!target->isOpened()); // flag protects from reveal
+    QVERIFY(target->isFlagged());
+}
+
+void TestMineField::testKeyboardIgnoredAfterLoss()
+{
+    MineField field;
+    field.setFixedLayout(3, 3, {{0, 0}});
+    field.cellAt(0, 0)->Open(); // boom
+    QCOMPARE(field.state(), GameState::Lost);
+
+    MineButton *safe = field.cellAt(2, 2);
+    QVERIFY(!safe->isOpened());
+    sendKey(safe, Qt::Key_F);
+    QCOMPARE(safe->marker(), CellMarker::None); // F ignored after loss
+    sendKey(safe, Qt::Key_Space);
+    // Note: after Lost, handleCellKey returns false for Space, so the event
+    // falls through to QPushButton. But QAbstractButton activation calls
+    // clicked() which nothing is wired to; cell remains un-opened either way.
+    QVERIFY(!safe->isOpened());
 }
 
 QTEST_MAIN(TestMineField)


### PR DESCRIPTION
## Summary

- Arrow keys move focus between cells; a blue inset ring shows which is active.
- **Space / Enter** reveal an unopened cell, or chord if the focused cell is already opened (mirrors the mouse UX — left-click vs. middle-click picks itself based on state).
- **F** toggles the marker (same three-state cycle as right-click: None → Flag → Question → None, honouring the `Enable question marks` setting).
- **D** forces chord on an opened cell — parallels middle-click.
- After `Won`/`Lost`, only arrow keys remain active so the user can look around a frozen board; action keys short-circuit.

## Motivation

Accessibility: today the app is unplayable without a mouse. The "keyboard navigation" item has been parked on every cycle's Next-candidates list since v1.3.0 (cycle 1) — seventh consecutive park. With no open feedback issues and a low-translation-cost opening, this autonomous cycle is the right one to clear it.

## Design note

- **Event filter on MineField** (rather than `keyPressEvent` on MineButton) is the only design that respects the project's "MineButton has no back-pointer to MineField" invariant while still handling arrow-key navigation, which requires knowledge of the grid. The filter intercepts KeyPress events on every child button before `QAbstractButton::keyPressEvent` sees them — this is critical for Space/Enter, which QAbstractButton otherwise routes to `clicked()`.
- **Focus ring via `paintEvent`**, not `:focus` stylesheet, because cell stylesheets change mid-game (opened, mine-reveal, wrong-flag); a paintEvent override is stylesheet-independent and survives every state.
- **Qt::StrongFocus explicit on MineButton** — macOS's `Qt::TabFocus` default would silently no-op arrow navigation on one platform only.
- `cycleMarker()` moved from private to public (cleanly — it's idempotent with the right-click path) so the event filter can invoke it without faking a synthetic `QMouseEvent`.

## Testing

- `tst_minefield.cpp`: 8 new cases (33→41 total). Arrow movement + boundary clamping, Space reveal + flood-fill, Space-on-opened-number chord, F three-state cycle, D chord, flag-protects-reveal, Won/Lost gating. All 41 pass under `QT_QPA_PLATFORM=offscreen`. Arrow-focus cases `show()` the field so `setFocus()` takes under offscreen platform.
- Live end-to-end verified on macOS: clicked into the grid, arrow+F placed a flag (mine count 10→9), arrow right + Space triggered flood-fill, focus ring visible throughout.
- `clang-format --dry-run --Werror *.cpp *.h tests/*.cpp` clean.
- **Zero new translatable strings.** 81/81 finished preserved per locale.

## Diff shape

7 files, +427 LOC total (DECISIONS.md ~107 of that, tests ~160, real code ~160). Under the 400-LOC cycle cap for real code. No new deps, no new QSettings keys, no state-machine changes.

## Assumptions (autonomous cycle)

- QAbstractButton does not pre-consume arrow keys outside a QButtonGroup — verified empirically; filter handles them unconditionally as defence-in-depth.
- Blue focus ring (2-px stroke, 1-px inset) is high-contrast against every cell stylesheet. Verified live on green-checker + tan-opened.
- D chosen for force-chord because it's F's QWERTY neighbour. Minesweeper clones don't have a de-facto key here.
- No auto-focus on new game — would conflict with menu-bar/consent-dialog focus during startup. Users Tab or click into the grid first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)