### PR TITLE
feat(v1.19.0): stats-dialog best-time columns adopt MM:SS clock format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(QMineSweeper
-    VERSION 1.18.0
+    VERSION 1.19.0
     DESCRIPTION "A Qt6-based Minesweeper game"
     HOMEPAGE_URL "https://github.com/Mavrikant/QMineSweeper"
     LANGUAGES CXX

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -882,10 +882,13 @@ void MainWindow::showStatsDialog()
         {
             return QStringLiteral("—");
         }
-        QString s = QString::asprintf("%.1f s", seconds);
+        // Duration-aware clock format matches the live timer label.
+        // The "s" unit is dropped because the column header carries it
+        // and "s" reads wrong on M:SS.S / H:MM:SS.S values.
+        QString s = formatElapsedTime(seconds);
         if (date.isValid())
         {
-            // Locale-formatted date in parentheses, e.g. "15.5 s (23.04.2026)".
+            // Locale-formatted date in parentheses, e.g. "1:30.5 (23.04.2026)".
             // Inline (vs. a separate column) keeps the row narrow and avoids
             // introducing another translatable column header per stat.
             s += QStringLiteral("  (") + QLocale().toString(date, QLocale::ShortFormat) + QStringLiteral(")");


### PR DESCRIPTION
## Summary

Stats-dialog **Best time** and **Best (no flag)** columns now reuse
`formatElapsedTime`, the duration-aware formatter shipped for the live
timer label in v1.18.0. This was the explicit follow-up listed under
v1.18.0's *Next candidates* in `CYCLES.md`.

| seconds stored | before     | after        |
|---------------:|------------|--------------|
| 45.0           | `45.0 s`   | `45.0`       |
| 95.5           | `95.5 s`   | `1:35.5`     |
| 754.5          | `754.5 s`  | `12:34.5`    |
| 3723.4         | `3723.4 s` | `1:02:03.4`  |

## Why

The live toolbar clock already renders in clock form past 60 s. The
stats column lagged behind, surfacing values like `754.5 s` that the
player has to mentally divide by 60 to compare against the in-game
display. Pairing the two formatters closes the loop.

## Design notes

- **Drop the " s" suffix.** "Best time" / "Best (no flag)" column
  headers carry the unit, and "s" reads wrong on `M:SS.S` /
  `H:MM:SS.S` values. Cleaner than a mixed-format scheme.
- **Zero new translatable strings.** Format is composed at runtime
  inside `formatElapsedTime`. All 10 locales stay at 90/90 finished.
- **No persistence change.** `bestSeconds` stays a `double` of seconds.
  Only the rendering changes; legacy QSettings load identically.
- **No new tests added.** The formatter is exhaustively unit-tested
  in `tst_time_format.cpp` (boundary cases, rounding carry across
  seconds/minutes/hours, defensive zero clamping). The change in
  `mainwindow.cpp` is a literal call swap to a tested helper.

## Alternatives rejected

- *Mixed format ("45.0 s" but "1:30.5").* Inconsistent within a
  single column.
- *Lift `formatBest` to a free function in `time_format.h` for
  testing.* Adds QLocale + QDate to the header for one call site;
  not worth the dependency surface.
- *Reformat the win-dialog "You cleared the field in %1 seconds."
  message.* Would burn 9 hand-translations on cosmetic change. Out
  of scope for this cycle.

## Backwards compat / rollout

- No persistence schema change.
- No new permissions / settings keys.
- No public API change.
- Worst-case regression is a stats-dialog string format; the formatter
  itself is pinned by 14 deterministic unit tests.

## Test plan

- [x] `ctest` — 6/6 suites green locally
- [x] `clang-format --dry-run --Werror` clean on all .cpp / .h
- [x] No new translatable strings (all 10 locales stay 90/90 finished)

🤖 Generated with [Claude Code](https://claude.com/claude-code)